### PR TITLE
Remove redis environment variable

### DIFF
--- a/lib/lita-raindar.rb
+++ b/lib/lita-raindar.rb
@@ -67,9 +67,15 @@ module Lita
         if code.nil?
           response.reply("Location not currently available")
         else
-          response.reply(UrlCache.cached_radar_url(code))
+          response.reply(url_cache.cached_radar_url(code))
         end
 
+      end
+
+      private
+
+      def url_cache
+        UrlCache.new(redis)
       end
 
       Lita.register_handler(self)

--- a/lib/url_cache.rb
+++ b/lib/url_cache.rb
@@ -2,14 +2,17 @@ require 'redis'
 require_relative "radar_generator"
 
 class UrlCache
-  REDIS = Redis.new(url: URI.parse(ENV["REDISTOGO_URL"] || "redis://127.0.0.1"))
   CACHE_EXPIRY = 300 # seconds
 
-  def self.cached_radar_url(radar_code)
-    radar_url = REDIS.get("#{radar_code}_gif")
+  def initialize(redis)
+    @redis = redis
+  end
+
+  def cached_radar_url(radar_code)
+    radar_url = @redis.get("#{radar_code}_gif")
     unless radar_url
       radar_url = RadarGenerator.gif(radar_code)
-      REDIS.set("#{radar_code}_gif", radar_url, ex: CACHE_EXPIRY)
+      @redis.set("#{radar_code}_gif", radar_url, ex: CACHE_EXPIRY)
     end
     radar_url
   end

--- a/spec/lita-raindar_spec.rb
+++ b/spec/lita-raindar_spec.rb
@@ -21,16 +21,17 @@ describe Lita::Handlers::Raindar, lita_handler: true do
   describe '.radar' do
     let(:handler) { Lita::Handlers::Raindar.new(robot) }
     let(:location) { "lita weather melbourne" }
+    let(:url_cache) { instance_double(UrlCache, cached_radar_url: true ) }
 
     before do
-      allow(UrlCache).to receive(:cached_radar_url)
+      allow(UrlCache).to receive(:new) { url_cache }
     end
 
     context 'when user requests Melbourne as downcase' do
       let(:response) { double(match_data: ['weather melbourne', 'melbourne'], reply: true) }
       it 'responds to specific argument' do
         handler.radar(response)
-        expect(UrlCache).to have_received(:cached_radar_url).with("IDR023")
+        expect(url_cache).to have_received(:cached_radar_url).with("IDR023")
       end
     end
 
@@ -38,7 +39,7 @@ describe Lita::Handlers::Raindar, lita_handler: true do
       let(:response) { double(match_data: ['weather Melbourne', 'Melbourne'], reply: true) }
       it 'responds to specific argument' do
         handler.radar(response)
-        expect(UrlCache).to have_received(:cached_radar_url).with("IDR023")
+        expect(url_cache).to have_received(:cached_radar_url).with("IDR023")
       end
     end
 
@@ -46,7 +47,7 @@ describe Lita::Handlers::Raindar, lita_handler: true do
       let(:response) { double(match_data: ['weather sydney', 'sydney'], reply: true) }
       it 'responds to specific argument' do
         handler.radar(response)
-        expect(UrlCache).to have_received(:cached_radar_url).with("IDR713")
+        expect(url_cache).to have_received(:cached_radar_url).with("IDR713")
       end
     end
 
@@ -54,7 +55,7 @@ describe Lita::Handlers::Raindar, lita_handler: true do
       let(:response) { double(match_data: ['weather wagga wagga', 'wagga wagga'], reply: true) }
       it 'responds to specific argument' do
         handler.radar(response)
-        expect(UrlCache).to have_received(:cached_radar_url).with("IDR553")
+        expect(url_cache).to have_received(:cached_radar_url).with("IDR553")
       end
     end
 
@@ -62,7 +63,7 @@ describe Lita::Handlers::Raindar, lita_handler: true do
       let(:response) { double(match_data: ['weather other location''other location'], reply: true) }
       it 'responds to specific argument' do
         handler.radar(response)
-        expect(UrlCache).to_not have_received(:cached_radar_url)
+        expect(url_cache).to_not have_received(:cached_radar_url)
         expect(response).to have_received(:reply).with("Location not currently available")
       end
     end

--- a/spec/url_cache_spec.rb
+++ b/spec/url_cache_spec.rb
@@ -3,13 +3,10 @@ require 'url_cache'
 describe UrlCache do
   describe '.cached_radar_url' do
     let(:radar_code) { "radar_code" }
+    let(:url_cache) { UrlCache.new instance_double(Redis, get: 'url') }
 
-    before do
-      stub_const("UrlCache::REDIS", instance_double(Redis, get: 'url'))
-
-    end
     it 'caches the url returned by the radar generator' do
-      expect(UrlCache.cached_radar_url(radar_code)).to eq 'url'
+      expect(url_cache.cached_radar_url(radar_code)).to eq 'url'
     end
   end
 


### PR DESCRIPTION
- Lita provides pre-configured redis object to each handler, so the environment variable is uncessecary
- Remove class method in favour of an initialize method with instance methods
