### PR TITLE
Remove imgur environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,15 @@ Or install it yourself as:
 
     $ gem install raindar
 
+## Configuration
+
+In `lita_config.rb`, it is necessary to set an `imgur_api_key`:
+
+    $ config.handlers.raindar.imgur_api_key = ENV["IMGUR_API_KEY"]
+
 ## Usage
 
-Once the gem is installed, the commands are as follows. Note that `lita` is used as an example. This will be your specific robot name
+Once the gem is installed and `imgur_api_key` set, the commands are as follows. Note that `lita` is used as an example. This will be your specific robot name
 
 ```
 lita weather LOCATION

--- a/lib/imgur_gateway.rb
+++ b/lib/imgur_gateway.rb
@@ -1,7 +1,6 @@
 require 'imgur'
 
 class ImgurGateway
-  IMGUR_API_KEY = ENV['IMGUR_API_KEY']
 
   attr_accessor :filename, :title, :url
 
@@ -12,7 +11,7 @@ class ImgurGateway
 
   def upload
     return false unless filename
-    client = Imgur.new(IMGUR_API_KEY)
+    client = Imgur.new(imgur_api_key)
     image = Imgur::LocalImage.new(filename, title: title)
     uploaded = client.upload(image)
     @url = uploaded.link
@@ -24,6 +23,10 @@ class ImgurGateway
 
   def image_title
     "Raindar #{Time.now.strftime('%A, %B %d, %Y')}"
+  end
+
+  def imgur_api_key
+    Lita.config.handlers.raindar.imgur_api_key
   end
 
 end

--- a/lib/lita-raindar.rb
+++ b/lib/lita-raindar.rb
@@ -4,6 +4,7 @@ require_relative "url_cache"
 module Lita
   module Handlers
     class Raindar < Handler
+      config :imgur_api_key
 
       route(/^weather ([a-zA-Z0-9\s]*)$/i, :radar, command: true, help: { "weather LOCATION" => "Returns GIF of recent weather radar" })
 


### PR DESCRIPTION
- Lita provides configuration which collects the imgur API key, so this PR removes the imgur API environment variable in favour of the lita config option.
