### PR TITLE
Ensure Tempfiles are Garbage Collected after use

### DIFF
--- a/lib/radar_generator.rb
+++ b/lib/radar_generator.rb
@@ -13,7 +13,7 @@ class RadarGenerator
     temporary_image_files = recent_image_filenames(radar_code).map do |radar_image|
       tempfile = Tempfile.new('composed')
 
-      system "convert -layers flatten #{template} #{raindar_url_for(radar_image)} #{tempfile.path}"
+      system "convert -layers flatten #{template.path} #{raindar_url_for(radar_image)} #{tempfile.path}"
       tempfile
     end
     composed_file_paths = temporary_image_files.map { |tempfile|

--- a/lib/template_generator.rb
+++ b/lib/template_generator.rb
@@ -7,7 +7,7 @@ class TemplateGenerator
 
     system "convert -layers flatten #{background(radar_code)} #{topography(radar_code)} #{range(radar_code)} #{locations(radar_code)} #{temporary_template.path}"
 
-    temporary_template.path
+    temporary_template
 
   end
 

--- a/spec/template_generator_spec.rb
+++ b/spec/template_generator_spec.rb
@@ -11,8 +11,9 @@ describe TemplateGenerator do
     end
 
     it 'generates a temporary template png file' do
-      expect(TemplateGenerator.template(radar_code)).to end_with('.png')
-      expect(TemplateGenerator.template(radar_code)).to include('temp_named_template')
+      expect(TemplateGenerator.template(radar_code)).to be_a(Tempfile)
+      expect(TemplateGenerator.template(radar_code).path).to end_with('.png')
+      expect(TemplateGenerator.template(radar_code).path).to include('temp_named_template')
     end
 
     it 'calls imagemagick correctly' do


### PR DESCRIPTION
Occasionally the template images of the radar weren't being displayed, resulting in a black/empty background.
The `TemplateGenerator` is using stdlib `Tempifle` to generate the temp path where the template is written. The files were often then garbage collected, but before the `RadarGenerate` could perform it's actions, resulting in the black backgrounds.
Calling `.path` on the `template` in `RadarGenerator` instead of in `TemplateGenerator` returns the tmpfile instance and ensures the tmpfiles are garbage collected _after_ final use.