### PR TITLE
Remove dependency on HTTParty

### DIFF
--- a/lib/radar_generator.rb
+++ b/lib/radar_generator.rb
@@ -1,4 +1,3 @@
-require 'httparty'
 require_relative 'imgur_gateway'
 require 'json'
 require 'tempfile'
@@ -48,7 +47,8 @@ class RadarGenerator
   end
 
   def self.most_recent_radar_image_json(radar_code)
-    HTTParty.get(raindar_image_json_url(radar_code)).response.body
+    uri = URI("#{raindar_image_json_url(radar_code)}")
+    Net::HTTP.get(uri)
   end
 
   def self.recent_image_filenames(radar_code)

--- a/lita-raindar.gemspec
+++ b/lita-raindar.gemspec
@@ -22,7 +22,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
 
-  spec.add_dependency "httparty"
   spec.add_dependency "imgur-api"
   spec.add_dependency "lita"
   spec.add_dependency "redis"

--- a/spec/radar_generator_spec.rb
+++ b/spec/radar_generator_spec.rb
@@ -18,9 +18,9 @@ EOF
 
     before do
 
-      allow(HTTParty).to receive(:get).
-        with('http://m.bom.gov.au/radar/radar_code.T.filenames.json').
-        and_return double(response: double(body: json_data))
+      allow(Net::HTTP).to receive(:get).
+        with(URI('http://m.bom.gov.au/radar/radar_code.T.filenames.json')).
+        and_return(json_data)
 
       allow(RadarGenerator).to receive(:system).with(anything) { true }
 


### PR DESCRIPTION
Previously, HTTParty was used to fetch a single JSON file. `Net::HTTP#get_response` does the same job without the gem dependency.