### PR TITLE
Remove require_relative

### DIFF
--- a/lib/lita-raindar.rb
+++ b/lib/lita-raindar.rb
@@ -1,4 +1,4 @@
-require "lita"
+require 'lita'
 require 'url_cache'
 
 module Lita

--- a/lib/lita-raindar.rb
+++ b/lib/lita-raindar.rb
@@ -1,5 +1,5 @@
 require "lita"
-require_relative "url_cache"
+require 'url_cache'
 
 module Lita
   module Handlers

--- a/lib/radar_generator.rb
+++ b/lib/radar_generator.rb
@@ -1,7 +1,7 @@
-require_relative 'imgur_gateway'
+require 'imgur_gateway'
 require 'json'
 require 'tempfile'
-require_relative 'template_generator'
+require 'template_generator'
 
 class RadarGenerator
   IMGUR_API_KEY = ENV['IMGUR_API_KEY']

--- a/lib/url_cache.rb
+++ b/lib/url_cache.rb
@@ -1,5 +1,5 @@
 require 'redis'
-require_relative "radar_generator"
+require 'radar_generator'
 
 class UrlCache
   CACHE_EXPIRY = 300 # seconds

--- a/spec/lita-raindar_spec.rb
+++ b/spec/lita-raindar_spec.rb
@@ -1,4 +1,4 @@
-require "lita-raindar"
+require 'lita-raindar'
 
 describe Lita::Handlers::Raindar, lita_handler: true do
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,4 @@
-require "lita-raindar"
-require "lita/rspec"
+require 'lita-raindar'
+require 'lita/rspec'
 
 Lita.version_3_compatibility_mode = false


### PR DESCRIPTION
I was using `require_relative` but the gem `lib/` directory will always be on the `$LOAD_PATH`. It's  fine to use plain `require`.
I also made a small change to improve the consistency of quotes in the `require`s.